### PR TITLE
run script update for glassfish7

### DIFF
--- a/docker/run_dsoltck.sh
+++ b/docker/run_dsoltck.sh
@@ -64,7 +64,7 @@ java -version
 
 ${GF_HOME}/vi/$GF_TOPLEVEL_DIR/glassfish/bin/asadmin --user admin --passwordfile ${GF_HOME}/change-admin-password.txt change-admin-password
 
-sed -i "s#<servlet-class>org.apache.jasper.servlet.JspServlet</servlet-class>#<servlet-class>org.apache.jasper.servlet.JspServlet</servlet-class>\n<init-param>\n<param-name>dumpSmap</param-name>\n<param-value>true</param-value>\n</init-param> #g" ${GF_HOME}/vi/$GF_TOPLEVEL_DIR/glassfish/domains/domain1/config/default-web.xml
+sed -i "s#<servlet-class>org.glassfish.wasp.servlet.JspServlet</servlet-class>#<servlet-class>org.glassfish.wasp.servlet.JspServlet</servlet-class>\n<init-param>\n<param-name>dumpSmap</param-name>\n<param-value>true</param-value>\n</init-param> #g" ${GF_HOME}/vi/$GF_TOPLEVEL_DIR/glassfish/domains/domain1/config/default-web.xml
 
 ${GF_HOME}/vi/$GF_TOPLEVEL_DIR/glassfish/bin/asadmin --user admin --passwordfile ${ADMIN_PASSWORD_FILE} start-domain
 


### PR DESCRIPTION
The org.apache.jasper.servlet.JspServlet in glassfish7/glassfish/domains/domain1/config/default-web.xml was replaced by org.glassfish.wasp.servlet.JspServlet. Using the same for the debugging tck run script.


Related issue : https://github.com/eclipse-ee4j/glassfish/issues/23962